### PR TITLE
Clear all for all

### DIFF
--- a/src/main/java/com/memoizrlabs/Shank.java
+++ b/src/main/java/com/memoizrlabs/Shank.java
@@ -230,6 +230,7 @@ public final class Shank {
         unscopedCache.clear();
         scopedCache.clear();
     }
+
     static void clearNamedScope(Scope scope) {
         scopedCache.remove(scope);
     }

--- a/src/main/java/com/memoizrlabs/Shank.java
+++ b/src/main/java/com/memoizrlabs/Shank.java
@@ -223,6 +223,13 @@ public final class Shank {
         return new ScopedCache(scope);
     }
 
+    /**
+     * Clears the entire cache.
+     */
+    public static void clearAll() {
+        unscopedCache.clear();
+        scopedCache.clear();
+    }
     static void clearNamedScope(Scope scope) {
         scopedCache.remove(scope);
     }
@@ -280,14 +287,6 @@ public final class Shank {
      */
     static void clearFactories() {
         factoryRegister.clear();
-    }
-
-    /**
-     * Clears the entire cache.
-     */
-    static void clearAll() {
-        unscopedCache.clear();
-        scopedCache.clear();
     }
 
     /**


### PR DESCRIPTION
When using Shank with Espresso we want to be able to provide different/new instances of singleton objects for different test runs. Presently though we can override Factories in our tests the singleton objects can never be overridden once created and cached.

Exposing `clearAll` will allow us to start each test with a clean slate where appropriate (as `ShankAcceptanceTest` does).
